### PR TITLE
Fix duplicate DB update and ready call

### DIFF
--- a/index.js
+++ b/index.js
@@ -66,8 +66,6 @@ const start = async () => {
   try {
     await app.after();
     await app.ready();
-
-    await app.ready();
     console.log('Schemas after app.ready():', app.getSchemas());
 
     await app.listen({

--- a/src/services/verifyMagicLinkService.js
+++ b/src/services/verifyMagicLinkService.js
@@ -32,10 +32,7 @@ export async function verifyMagicLink(token) {
       return { success: false, message: 'Token has expired' };
     }
 
-    // Mark token as used
-    await runAsync('UPDATE magic_links SET used = 1 WHERE token = ?', [token]);
-
-    // Mark token as used
+    // Mark token as used only once
     await runAsync('UPDATE magic_links SET used = 1 WHERE token = ?', [token]);
 
     // Mark email as verified


### PR DESCRIPTION
## Summary
- remove duplicate DB update in `verifyMagicLinkService`
- clean up repeated `app.ready()` call in `index.js`

## Testing
- `npx vitest run` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6846d91a33e883279b0bed9d0829a8b2